### PR TITLE
Fixes non-ASCII character error

### DIFF
--- a/render.py
+++ b/render.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 """
 Spartan command-line halite.io replay viewer.


### PR DESCRIPTION
File "./render.py", line 27
SyntaxError: Non-ASCII character '\xe2' in file ./render.py on line 27, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details